### PR TITLE
[Fix] Remove MAINTAINER deprecated reference

### DIFF
--- a/image/5.6/jessie/Dockerfile
+++ b/image/5.6/jessie/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-MAINTAINER Florent DESPIERRES <florent@despierres.pro>
+LABEL maintainer="Florent DESPIERRES <florent@despierres.pro> Michael COULLERET <michael@coulleret.pro>"
 
 # Copy all scripts
 COPY ./image/scripts/*.sh /tmp/

--- a/image/5.6/wheezy/Dockerfile
+++ b/image/5.6/wheezy/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:wheezy
 
-MAINTAINER Florent DESPIERRES <florent@despierres.pro>
+LABEL maintainer="Florent DESPIERRES <florent@despierres.pro> Michael COULLERET <michael@coulleret.pro>"
 
 # Copy all scripts
 COPY ./image/scripts/*.sh /tmp/

--- a/image/7.0/jessie/Dockerfile
+++ b/image/7.0/jessie/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-MAINTAINER Florent DESPIERRES <florent@despierres.pro>
+LABEL maintainer="Florent DESPIERRES <florent@despierres.pro> Michael COULLERET <michael@coulleret.pro>"
 
 # Copy all scripts
 COPY ./image/scripts/*.sh /tmp/

--- a/image/7.0/stretch/Dockerfile
+++ b/image/7.0/stretch/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch
 
-MAINTAINER Florent DESPIERRES <florent@despierres.pro>
+LABEL maintainer="Florent DESPIERRES <florent@despierres.pro> Michael COULLERET <michael@coulleret.pro>"
 
 # Copy all scripts
 COPY ./image/scripts/*.sh /tmp/

--- a/image/7.1/jessie/Dockerfile
+++ b/image/7.1/jessie/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-MAINTAINER Florent DESPIERRES <florent@despierres.pro>
+LABEL maintainer="Florent DESPIERRES <florent@despierres.pro> Michael COULLERET <michael@coulleret.pro>"
 
 # Copy all scripts
 COPY ./image/scripts/*.sh /tmp/

--- a/image/7.1/stretch/Dockerfile
+++ b/image/7.1/stretch/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch
 
-MAINTAINER Florent DESPIERRES <florent@despierres.pro>
+LABEL maintainer="Florent DESPIERRES <florent@despierres.pro> Michael COULLERET <michael@coulleret.pro>"
 
 # Copy all scripts
 COPY ./image/scripts/*.sh /tmp/


### PR DESCRIPTION
Remove deprecated reference, see https://docs.docker.com/engine/reference/builder/#maintainer-deprecated